### PR TITLE
Bug fix: held lock longer than max duration

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,6 +434,7 @@ const Lock = function(config)
                 // refuse to refresh lock after maximumDurationMs
                 const now = (new Date()).getTime();
                 if (self._config.maximumDurationMs && (now - self._firstAcquisitionTime > self._config.maximumDurationMs)) {
+                    resolve();
                     return;
                 }
 


### PR DESCRIPTION
## Description
resolve promise for heartbeat after maxDuration has passed since acquiring lock
This lead to a bug where program would exit unexpectedly with exit code 0.


## Reproducible demo
https://github.com/skio-org/frost/pull/7053/files
This PR has the reproducible demo


## Testing
`npm test` reported no errors






