### PR TITLE
emit lockExpired event when maximumDurationMs timeout is hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Creates a "fail open" client that acquires "fail open" locks. If process crashes
      Sort key part of `id` is only required if lock is configured with a sort key. The types of partition key and sort key must correspond to lock table's partition key and sort key types.
   * `callback`: _Function_ `(error, lock) => {}`
     * `error`: _Error_ Error, if any.
-    * `lock`: _DynamoDBLockClient.Lock_ Successfully acquired lock object. Lock object is an instance of `EventEmitter`. If the `lock` is acquired via a fail open `client` configured to heartbeat, then the returned `lock` may emit an `error` event if a `heartbeat` operation fails.
+    * `lock`: _DynamoDBLockClient.Lock_ Successfully acquired lock object. Lock object is an instance of `EventEmitter`. If the `lock` is acquired via a fail open `client` configured to heartbeat, then the returned `lock` may emit an `error` event if a `heartbeat` operation fails. If `maximumDurationMs` is configured, the `lock` will emit a `lockExpired` event when the maximum duration is exceeded and heartbeats stop. The event payload is `{ partitionID, sortID, maximumDurationMs, elapsedMs }`.
       * `fencingToken`: _Integer_ **fail open locks only** Integer monotonically incremented with every "fail open" lock acquisition to be used for [fencing](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html#making-the-lock-safe-with-fencing). Heartbeats do not increment `fencingToken`.
 
 Attempts to acquire a lock. If lock acquisition fails, callback will be called with an `error` and `lock` will be falsy. If lock acquisition succeeds, callback will be called with `lock`, and `error` will be falsy.

--- a/index.js
+++ b/index.js
@@ -438,6 +438,13 @@ const Lock = function(config)
                 if (self._config.maximumDurationMs && (now - self._firstAcquisitionTime > self._config.maximumDurationMs)) {
                     self._heartbeatPromise = null;
                     resolve();
+                    self.emit("lockExpired",
+                    {
+                        partitionID: self._config.partitionID,
+                        sortID: self._config.sortID,
+                        maximumDurationMs: self._config.maximumDurationMs,
+                        elapsedMs: now - self._firstAcquisitionTime
+                    });
                     return;
                 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -1379,3 +1379,86 @@ describe("FailOpen lock release", () =>
         );
     });
 });
+
+describe("FailOpen lock maximumDurationMs lockExpired event", () =>
+{
+    let config, dynamodb;
+    beforeEach(() =>
+        {
+            config =
+            {
+                lockTable: LOCK_TABLE,
+                partitionKey: PARTITION_KEY,
+                heartbeatPeriodMs: HEARTBEAT_PERIOD_MS,
+                leaseDurationMs: LEASE_DURATION_MS,
+                owner: OWNER
+            };
+            dynamodb =
+            {
+                delete: () => {},
+                get: (_, callback) => callback(undefined, {}),
+                put: (_, callback) => callback()
+            };
+        }
+    );
+
+    test("emits lockExpired event when maximumDurationMs is exceeded", done =>
+        {
+            const guid = crypto.randomBytes(64);
+            const lock = new DynamoDBLockClient.Lock(
+                {
+                    dynamodb,
+                    fencingToken: 1,
+                    guid,
+                    heartbeatPeriodMs: HEARTBEAT_PERIOD_MS,
+                    maximumDurationMs: 1,
+                    leaseDurationMs: LEASE_DURATION_MS,
+                    lockTable: LOCK_TABLE,
+                    owner: OWNER,
+                    partitionID: LOCK_ID,
+                    partitionKey: PARTITION_KEY,
+                    type: DynamoDBLockClient.FailOpen
+                }
+            );
+            lock.on("lockExpired", data =>
+                {
+                    expect(data.partitionID).toBe(LOCK_ID);
+                    expect(data.sortID).toBe(undefined);
+                    expect(data.maximumDurationMs).toBe(1);
+                    expect(typeof data.elapsedMs).toBe("number");
+                    expect(data.elapsedMs).toBeGreaterThanOrEqual(0);
+                    clearTimeout(lock.heartbeatTimeout);
+                    done();
+                }
+            );
+        }
+    );
+
+    test("does not emit lockExpired when maximumDurationMs is not configured", done =>
+        {
+            config.dynamodb = dynamodb;
+            // no maximumDurationMs configured
+            const failOpen = new DynamoDBLockClient.FailOpen(config);
+            failOpen.acquireLock(LOCK_ID, (error, lock) =>
+                {
+                    expect(error).toBe(undefined);
+                    lock.on("lockExpired", () =>
+                        {
+                            done(new Error("should not emit lockExpired"));
+                        }
+                    );
+                    // wait enough for a couple heartbeats, then release
+                    setTimeout(() =>
+                        {
+                            lock.release(err =>
+                                {
+                                    done();
+                                }
+                            );
+                        }, HEARTBEAT_PERIOD_MS * 3
+                    );
+                }
+            );
+        }
+    );
+});


### PR DESCRIPTION
Allow clients to be notified when a lock's maximum duration is exceeded and heartbeats stop, so they can log and take corrective action.